### PR TITLE
Fix issue #11 - Report user chat history like Unity

### DIFF
--- a/src/components/chat-history/ChatHistoryView.scss
+++ b/src/components/chat-history/ChatHistoryView.scss
@@ -2,3 +2,7 @@
     width: $chat-history-width;
     height: $chat-history-height;
 }
+
+.cursor-pointer {
+    cursor: pointer;
+}

--- a/src/components/chat-history/ChatHistoryView.tsx
+++ b/src/components/chat-history/ChatHistoryView.tsx
@@ -1,16 +1,18 @@
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { ILinkEventTracker } from '@nitrots/nitro-renderer';
 import { FC, useEffect, useMemo, useState } from 'react';
-import { AddEventLinkTracker, ChatEntryType, LocalizeText, RemoveLinkEventTracker } from '../../api';
+import { AddEventLinkTracker, ChatEntryType, GetSessionDataManager, GetUserProfile, LocalizeText, RemoveLinkEventTracker, ReportType } from '../../api';
 import { Flex, InfiniteScroll, NitroCardContentView, NitroCardHeaderView, NitroCardView, Text } from '../../common';
-import { useChatHistory } from '../../hooks';
+import { useChatHistory, useHelp } from '../../hooks';
 
 export const ChatHistoryView: FC<{}> = props =>
 {
     const [ isVisible, setIsVisible ] = useState(false);
     const [ searchText, setSearchText ] = useState<string>('');
-    const { chatHistory = [] } = useChatHistory();
+    const { chatHistory = [], setMessengerHistory, addMessengerEntry } = useChatHistory();
+    const { report = null } = useHelp();
 
-    const filteredChatHistory = useMemo(() => 
+    const filteredChatHistory = useMemo(() =>
     {
         if (searchText.length === 0) return chatHistory;
 
@@ -18,6 +20,13 @@ export const ChatHistoryView: FC<{}> = props =>
 
         return chatHistory.filter(entry => ((entry.message && entry.message.toLowerCase().includes(text))) || (entry.name && entry.name.toLowerCase().includes(text)));
     }, [ chatHistory, searchText ]);
+
+    const reportMessage = (message: any) =>
+    {
+        setMessengerHistory([]); // We do this because we are interested in displaying only the reported message.
+        report(ReportType.IM, { reportedUserId: message.webId });
+        addMessengerEntry({ id: message.id, webId: message.webId, entityId: message.entityId, name: message.name, timestamp: message.timestamp, type: ChatEntryType.TYPE_IM, roomId: message.roomId, message: message.message });
+    }
 
     /* useEffect(() =>
     {
@@ -30,9 +39,9 @@ export const ChatHistoryView: FC<{}> = props =>
             linkReceived: (url: string) =>
             {
                 const parts = url.split('/');
-        
+
                 if(parts.length < 2) return;
-        
+
                 switch(parts[1])
                 {
                     case 'show':
@@ -66,12 +75,15 @@ export const ChatHistoryView: FC<{}> = props =>
                     return (
                         <Flex alignItems="center" className="p-1" gap={ 2 }>
                             <Text variant="muted">{ row.timestamp }</Text>
+                            { (row.type === ChatEntryType.TYPE_CHAT && GetSessionDataManager().userId !== row.webId ) &&
+                                <FontAwesomeIcon cursor="pointer" color="red" icon="flag" onClick={ () => reportMessage(row) } />
+                            }
                             { (row.type === ChatEntryType.TYPE_CHAT) &&
                                 <div className="bubble-container" style={ { position: 'relative' } }>
                                     { (row.style === 0) &&
                                     <div className="user-container-bg" style={ { backgroundColor: row.color } } /> }
                                     <div className={ `chat-bubble bubble-${ row.style } type-${ row.chatType }` } style={ { maxWidth: '100%' } }>
-                                        <div className="user-container">
+                                        <div className="user-container cursor-pointer" onClick={ event => GetUserProfile(row.webId) }>
                                             { row.imageUrl && (row.imageUrl.length > 0) &&
                                 <div className="user-image" style={ { backgroundImage: `url(${ row.imageUrl })` } } /> }
                                         </div>

--- a/src/hooks/chat-history/useChatHistory.ts
+++ b/src/hooks/chat-history/useChatHistory.ts
@@ -97,8 +97,8 @@ const useChatHistoryState = () =>
 
         addMessengerEntry({ id: -1, webId: parser.senderId, entityId: -1, name: '', message: parser.messageText, roomId: -1, timestamp: MessengerHistoryCurrentDate(), type: ChatEntryType.TYPE_IM });
     });
-    
-    return { addChatEntry, chatHistory, roomHistory, messengerHistory };
+
+    return { addChatEntry, chatHistory, roomHistory, messengerHistory, setMessengerHistory, addMessengerEntry };
 }
 
 export const useChatHistory = () => useBetween(useChatHistoryState);


### PR DESCRIPTION
It has its functions:

- If the user himself sends the message, the report does not appear (it is obvious that he will not report himself)

- We have also added a functionality, in which when you click on the nickname or avatar, the user profile opens

- Finally, the reported message will be updated according to which history line you report

![imagen](https://user-images.githubusercontent.com/110488133/206530666-ce208f60-3f18-4ec7-982b-16d7cd9899b7.png)