### PR TITLE
feat/songinfo: Show correct Songinfo in Inventory

### DIFF
--- a/src/components/inventory/views/furniture/InventoryFurnitureView.tsx
+++ b/src/components/inventory/views/furniture/InventoryFurnitureView.tsx
@@ -128,7 +128,10 @@ export const InventoryFurnitureView: FC<InventoryFurnitureViewProps> = props =>
                 </Column>
                 { selectedItem &&
                     <Column grow justifyContent="between" gap={ 2 }>
-                        <Text grow truncate>{ selectedItem.name }</Text>
+                        <Column grow gap={ 1 }>
+                            <Text bold>{ selectedItem.name }</Text>
+                            <Text>{ selectedItem.description }</Text>
+                        </Column>
                         <Column gap={ 1 }>
                             { !!roomSession &&
                                 <Button variant="success" onClick={ event => attemptItemPlacement(selectedItem) }>


### PR DESCRIPTION
In the current dev branch, song names are only visible when placed in the room. In the inventory, the item name is `SONG_NAME`.
![image](https://user-images.githubusercontent.com/10966337/225372303-0270d9bc-c75f-4fa4-b63e-bbb3c363278b.png)

Current official implementation:
![image](https://user-images.githubusercontent.com/10966337/225372761-2dbbe178-d115-45a4-8d13-d9935356518d.png)

Look & feels with my changes:
![image](https://user-images.githubusercontent.com/10966337/225373061-226cc9a1-cc0f-4c07-b63c-c730f3a71b29.png)


This why I am committing this PR. As you can see, the name is written bold in the inventory, like in the official client. Also, the description is visible. The name is used for the creator's name, the description is used for the song title. Because the songinfo can lazy load, a callback is also implemented and cleared when not used.
I hope this implementation is in the spirit of @billsonnn and @dank074 if not i am open for changes. 🙌🏼