### PR TITLE
Feature - Rentable Spaces

### DIFF
--- a/src/components/room/widgets/furniture/FurnitureRentableSpaceView.tsx
+++ b/src/components/room/widgets/furniture/FurnitureRentableSpaceView.tsx
@@ -1,0 +1,43 @@
+import { FriendlyTime } from '@nitrots/nitro-renderer';
+import { FC } from 'react';
+import { LocalizeText } from '../../../../api';
+import { Button, Column, Flex, LayoutCurrencyIcon, NitroCardContentView, NitroCardHeaderView, NitroCardView, Text } from '../../../../common';
+import { useFurnitureRentableSpaceWidget } from '../../../../hooks';
+
+export const FurnitureRentableSpaceView: FC<{}> = props =>
+{
+    const { renter, isRoomOwner, onRent, onCancelRent, onClose } = useFurnitureRentableSpaceWidget();
+    
+    if(!renter) return null;
+
+    return (
+        <NitroCardView className="nitro-guide-tool no-resize" theme="primary-slim">
+            <NitroCardHeaderView headerText={ LocalizeText('rentablespace.widget.title') } onCloseClick={ onClose } />
+            <NitroCardContentView className="text-black">
+                <Column>
+                    { (!renter.rented) &&
+                        <>
+                            <Text>{ LocalizeText('rentablespace.widget.instructions') }</Text>
+                            <Flex pointer center className="p-2 bg-primary border border-dark rounded text-light h3" onClick={ onRent }>
+                                { renter.price + ' x' }&nbsp;
+                                <LayoutCurrencyIcon type={ -1 } className="mt-1" />&nbsp;
+                                { LocalizeText('catalog.purchase_confirmation.rent') }
+                            </Flex>
+                        </>
+                    }
+                    { (renter.rented) &&
+                        <>
+                            <Text bold>{ LocalizeText('rentablespace.widget.rented_to_label') }</Text>
+                            <Text italics>{ renter.renterName }</Text>
+                            <Text bold>{ LocalizeText('rentablespace.widget.expires_label') }</Text>
+                            <Text italics>{ FriendlyTime.shortFormat(renter.timeRemaining) }</Text>
+                            { (isRoomOwner) &&
+                                <Button variant="danger" className="mt-2" onClick={ onCancelRent }>{ LocalizeText('rentablespace.widget.cancel_rent') }</Button> }
+
+                        </>
+                    }
+                </Column>
+            </NitroCardContentView>
+        </NitroCardView>
+    );
+}

--- a/src/components/room/widgets/furniture/FurnitureWidgetsView.tsx
+++ b/src/components/room/widgets/furniture/FurnitureWidgetsView.tsx
@@ -1,6 +1,5 @@
 import { FC } from 'react';
 import { Base } from '../../../../common';
-import { FurnitureContextMenuView } from './context-menu/FurnitureContextMenuView';
 import { FurnitureBackgroundColorView } from './FurnitureBackgroundColorView';
 import { FurnitureBadgeDisplayView } from './FurnitureBadgeDisplayView';
 import { FurnitureCraftingView } from './FurnitureCraftingView';
@@ -12,12 +11,14 @@ import { FurnitureGiftOpeningView } from './FurnitureGiftOpeningView';
 import { FurnitureHighScoreView } from './FurnitureHighScoreView';
 import { FurnitureInternalLinkView } from './FurnitureInternalLinkView';
 import { FurnitureMannequinView } from './FurnitureMannequinView';
+import { FurnitureRentableSpaceView } from './FurnitureRentableSpaceView';
 import { FurnitureRoomLinkView } from './FurnitureRoomLinkView';
 import { FurnitureSpamWallPostItView } from './FurnitureSpamWallPostItView';
 import { FurnitureStackHeightView } from './FurnitureStackHeightView';
 import { FurnitureStickieView } from './FurnitureStickieView';
 import { FurnitureTrophyView } from './FurnitureTrophyView';
 import { FurnitureYoutubeDisplayView } from './FurnitureYoutubeDisplayView';
+import { FurnitureContextMenuView } from './context-menu/FurnitureContextMenuView';
 import { FurniturePlaylistEditorWidgetView } from './playlist-editor/FurniturePlaylistEditorWidgetView';
 
 export const FurnitureWidgetsView: FC<{}> = props =>
@@ -43,6 +44,7 @@ export const FurnitureWidgetsView: FC<{}> = props =>
             <FurnitureTrophyView />
             <FurnitureContextMenuView />
             <FurnitureYoutubeDisplayView />
+            <FurnitureRentableSpaceView />
         </Base>
     );
 }

--- a/src/hooks/rooms/widgets/furniture/index.ts
+++ b/src/hooks/rooms/widgets/furniture/index.ts
@@ -11,6 +11,7 @@ export * from './useFurnitureInternalLinkWidget';
 export * from './useFurnitureMannequinWidget';
 export * from './useFurniturePlaylistEditorWidget';
 export * from './useFurniturePresentWidget';
+export * from './useFurnitureRentableSpaceWidget';
 export * from './useFurnitureRoomLinkWidget';
 export * from './useFurnitureSpamWallPostItWidget';
 export * from './useFurnitureStackHeightWidget';

--- a/src/hooks/rooms/widgets/furniture/useFurnitureRentableSpaceWidget.ts
+++ b/src/hooks/rooms/widgets/furniture/useFurnitureRentableSpaceWidget.ts
@@ -1,0 +1,116 @@
+import { RentableSpaceCancelRentMessageComposer, RentableSpaceRentMessageComposer, RentableSpaceStatusMessageEvent, RentableSpaceStatusMessageParser, RoomEngineTriggerWidgetEvent, RoomWidgetEnum } from '@nitrots/nitro-renderer';
+import { useState } from 'react';
+import { GetRoomEngine, GetSessionDataManager, LocalizeText, SendMessageComposer } from '../../../../api';
+import { useMessageEvent, useRoomEngineEvent } from '../../../events';
+import { useNavigator } from '../../../navigator';
+import { useNotification } from '../../../notification';
+import { useFurniRemovedEvent } from '../../engine';
+
+const useFurnitureRentableSpaceWidgetState = () =>
+{
+    const [ renter, setRenter ] = useState<RentableSpaceStatusMessageParser>(null);
+    const [ itemId, setItemId ] = useState<number>(-1);
+    const [ category, setCategory ] = useState<number>(-1);
+    const { navigatorData = null } = useNavigator();
+    const { simpleAlert } = useNotification();
+
+    const isRoomOwner = GetSessionDataManager().userName === navigatorData.enteredGuestRoom.ownerName;    
+
+    const onClose = () =>
+    {
+        setItemId(-1);
+        setCategory(-1);
+        setRenter(null);
+    }
+
+    const onRent = () =>
+    {
+        if (!itemId) return;
+        
+        SendMessageComposer(new RentableSpaceRentMessageComposer(itemId));
+    }
+
+    const onCancelRent = () =>
+    {
+        if (!itemId) return;
+        
+        SendMessageComposer(new RentableSpaceCancelRentMessageComposer(itemId));
+        onClose();
+    }
+
+    const getRentErrorCode = (code: number) =>
+    {
+        let errorAlert = '';
+
+        switch(code)
+        {
+            case RentableSpaceStatusMessageParser.SPACE_ALREADY_RENTED:
+                errorAlert = LocalizeText('rentablespace.widget.error_reason_already_rented');
+                break;
+            case RentableSpaceStatusMessageParser.SPACE_EXTEND_NOT_RENTED:
+                errorAlert = LocalizeText('rentablespace.widget.error_reason_not_rented');
+                break;
+            case RentableSpaceStatusMessageParser.SPACE_EXTEND_NOT_RENTED_BY_YOU:
+                errorAlert = LocalizeText('rentablespace.widget.error_reason_not_rented_by_you');
+                break;
+            case RentableSpaceStatusMessageParser.CAN_RENT_ONLY_ONE_SPACE:
+                errorAlert = LocalizeText('rentablespace.widget.error_reason_can_rent_only_one_space');
+                break;
+            case RentableSpaceStatusMessageParser.NOT_ENOUGH_CREDITS:
+                errorAlert = LocalizeText('rentablespace.widget.error_reason_not_enough_credits');
+                break;
+            case RentableSpaceStatusMessageParser.NOT_ENOUGH_PIXELS:
+                errorAlert = LocalizeText('rentablespace.widget.error_reason_not_enough_duckets');
+                break;
+            case RentableSpaceStatusMessageParser.CANT_RENT_NO_PERMISSION:
+                errorAlert = LocalizeText('rentablespace.widget.error_reason_no_permission');
+                break;
+            case RentableSpaceStatusMessageParser.CANT_RENT_NO_HABBO_CLUB:
+                errorAlert = LocalizeText('rentablespace.widget.error_reason_no_habboclub');
+                break;
+            case RentableSpaceStatusMessageParser.CANT_RENT:
+                errorAlert = LocalizeText('rentablespace.widget.error_reason_disabled');
+                break;
+            case RentableSpaceStatusMessageParser.CANT_RENT_GENERIC:
+                errorAlert = LocalizeText('rentablespace.widget.error_reason_generic');
+                break;
+        }
+        
+        onClose();
+        return simpleAlert(errorAlert);
+    }
+
+    useRoomEngineEvent<RoomEngineTriggerWidgetEvent>(RoomEngineTriggerWidgetEvent.OPEN_WIDGET, event =>
+    {
+        if (event.widget !== RoomWidgetEnum.RENTABLESPACE) return;
+        
+        const roomObject = GetRoomEngine().getRoomObject(event.roomId, event.objectId, event.category);
+        
+        if(!roomObject) return;
+
+        setItemId(roomObject.id);
+        setCategory(event.category);
+    });
+
+    useFurniRemovedEvent(((itemId !== -1) && (category !== -1)), event =>
+    {
+        if((event.id !== itemId) || (event.category !== category)) return;
+
+        onCancelRent();
+    });
+
+    useMessageEvent<RentableSpaceStatusMessageEvent>(RentableSpaceStatusMessageEvent, event =>
+    {
+        const parser = event.getParser();
+
+        if (!parser) return;
+        
+        if (parser.canRentErrorCode !== 0 && (!isRoomOwner || !GetSessionDataManager().isModerator) || (parser.renterName === '' && parser.canRentErrorCode !== 0)) return getRentErrorCode(parser.canRentErrorCode);
+        
+        setRenter(parser);
+    });
+
+    return { renter, isRoomOwner, onRent, onCancelRent, onClose };
+}
+
+export const useFurnitureRentableSpaceWidget = useFurnitureRentableSpaceWidgetState;


### PR DESCRIPTION
The Rentable Spaces has arrived in Nitro v2!

**IMPORTANT**: FIRST you MUST update the following Nitro Renderer, otherwise it WILL NOT WORK for you: https://github.com/billsonnn/nitro-renderer/pull/102

To buy the furni is in the catalog as **Palooza - Spacerent**

Once purchased, place it in the room.

I'm a normal user, I'm not staff or anything, and I can rent this little square, so you'll have to double click on the poster or the border, so, we click Rent

![imagen](https://user-images.githubusercontent.com/110488133/230739772-38aed92c-9b58-44de-ace1-96b073685550.png)

Once rented, it will look like this color and I can place my furni only in this space, and there will be information about who has rented it and its duration

![imagen](https://user-images.githubusercontent.com/110488133/230739870-292b0721-c1e2-495c-956a-3ea19b163cd6.png)

Now, as the owner of the room, I can cancel the rental rented by another person or, if I rent my part, I can also remove it. (this is how it is done in the emulator)

If you pay attention, if I am not the one who has rented that space, the green color does not appear, only the border appears without the green color or the sign

If the owner of the room cancels a rental, the furni of that part will be removed and taken to the inventory of the rented user

![imagen](https://user-images.githubusercontent.com/110488133/230739913-c656eb87-92ea-4b84-affa-f0d29c6b095f.png)

If I try to rent another space, it won't let me because I currently have an active rental, that's why the error message.

Enjoy the new feature! ❤️ 

![imagen](https://user-images.githubusercontent.com/110488133/230739982-810e322c-3601-457a-a848-9cdb38be806b.png)