### PR TITLE
fix: remove asynchronous callback

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -24,7 +24,7 @@ export const App: FC<{}> = props =>
         Nitro.bootstrap();
     }
 
-    const handler = useCallback(async (event: NitroEvent) =>
+    const handler = useCallback((event: NitroEvent) =>
     {
         switch(event.type)
         {
@@ -82,19 +82,20 @@ export const App: FC<{}> = props =>
 
                 if(assetUrls && assetUrls.length) for(const url of assetUrls) urls.push(NitroConfiguration.interpolate(url));
 
-                const status = await GetAssetManager().downloadAssets(urls);
-                
-                if(status)
-                {
-                    GetCommunication().init();
+                GetAssetManager().downloadAssets(urls)
+                  .then((status) => {
+                      if(status)
+                      {
+                          GetCommunication().init();
 
-                    setPercent(prevValue => (prevValue + 20))
-                }
-                else
-                {
-                    setIsError(true);
-                    setMessage('Assets Failed');
-                }
+                          setPercent(prevValue => (prevValue + 20))
+                      }
+                      else
+                      {
+                          setIsError(true);
+                          setMessage('Assets Failed');
+                      }
+                  })
                 return;
             }
         }


### PR DESCRIPTION
in React, using async directly within the useCallback function is generally discouraged. The primary reason is that hooks in React are designed to be pure functions that do not produce side effects, and the async keyword inherently introduces a side effect by returning a Promise.

to resolve this, I've removed the async keyword from the useCallback function and instead added a then() clause to the Promise inside of it. This way, we are still able to handle asynchronous operations but do so in a manner that aligns with the intended use of React hooks. This should provide the same functionality but with more adherence to React's best practices.