### PR TITLE
fix: continues #115, song disk bug

### DIFF
--- a/src/api/inventory/GroupItem.ts
+++ b/src/api/inventory/GroupItem.ts
@@ -1,4 +1,4 @@
-import { IObjectData, IRoomEngine } from '@nitrots/nitro-renderer';
+import { IObjectData, IRoomEngine, LegacyDataType } from '@nitrots/nitro-renderer';
 import { LocalizeText } from '../utils';
 import { FurniCategory } from './FurniCategory';
 import { FurnitureItem } from './FurnitureItem';
@@ -322,7 +322,15 @@ export class GroupItem
                 key = (('poster_' + k.stuffData.getLegacyString()) + '_name');
                 break;
             case FurniCategory.TRAX_SONG:
-                this._name = 'SONG_NAME';
+                if(k.stuffData instanceof LegacyDataType) 
+                {
+                    let stuffName = k.stuffData.getLegacyStringWithOffset(5);
+                    // Just checking if not undefined
+                    if(stuffName)
+                        this._name = stuffName;
+                }
+                else 
+                    this._name = 'SONG_NAME'
                 return;
             default:
                 if(this.isWallItem)


### PR DESCRIPTION
It's simple, I've provided the fix to this bug in Arcturus already, but not in React yet, took a long time, because I was working with another projects.

But to explain, it's simple, it gets the song name from the offset 5 in stuffData that has the format of a LegacyDataType, this method ``getLegacyStringWithOffset`` was not in nitro-renderer, for that reason I've opened some PR there also: billsonnn/nitro-renderer#105, If the song name wasn't found in stuffName, just set it to the old ``SONG_NAME``

![inventory](https://github.com/billsonnn/nitro-react/assets/24923784/12e48759-c066-46c2-9184-69090ffa93c8)

Fixed in Arcturus Community (ms4/dev), found that was related to a packet [Merge Request in Arcturus](https://git.krews.org/morningstar/Arcturus-Community/-/merge_requests/16)

![1avatarinfo](https://github.com/billsonnn/nitro-react/assets/24923784/90406e3c-66a0-4831-954d-a71adb60372c)

TLDR: This will fix the song name in inventory, showing the correct name

Fixes: #86 
Continues: #115