### PR TITLE
prevent scrolling canvas on mobile

### DIFF
--- a/src/components/floorplan-editor/common/FloorplanEditor.ts
+++ b/src/components/floorplan-editor/common/FloorplanEditor.ts
@@ -33,6 +33,8 @@ export class FloorplanEditor
         canvas.height = height;
         canvas.width = width;
 
+        canvas.style.touchAction = 'none';
+
         this._renderer = canvas.getContext('2d');
 
         this._image = new Image();

--- a/src/components/floorplan-editor/views/FloorplanCanvasView.tsx
+++ b/src/components/floorplan-editor/views/FloorplanCanvasView.tsx
@@ -138,8 +138,7 @@ export const FloorplanCanvasView: FC<ColumnProps> = props =>
         const currentElement = elementRef.current;
 
         if(!currentElement) return;
-
-        
+                
         currentElement.appendChild(FloorplanEditor.instance.renderer.canvas);
 
         currentElement.addEventListener('pointerup', onPointerEvent);


### PR DESCRIPTION
prevent scrolling the canvas when dragging your finger on the canvas to draw the floor