### PR TITLE
Check if image exists before setting onload

### DIFF
--- a/src/common/layout/LayoutFurniImageView.tsx
+++ b/src/common/layout/LayoutFurniImageView.tsx
@@ -72,7 +72,9 @@ export const LayoutFurniImageView: FC<LayoutFurniImageViewProps> = props =>
         {
             const image = imageResult.getImage();
 
-            image.onload = () => setImageElement(image);
+            if(image) {
+                image.onload = () => setImageElement(image);
+            }
         }
     }, [ productType, productClassId, direction, extraData ]);
 


### PR DESCRIPTION
fixes nitro crash when trying to place certain items on the marketplace